### PR TITLE
Do not enumerate assembly classes twice when looking for installed packages

### DIFF
--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/AppCenterEditorSDK/Constants.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/AppCenterEditorSDK/Constants.cs
@@ -3,5 +3,7 @@
     public class Constants
     {
         public const string UnknownVersion = "Unknown";
+        public const string WrapperSdkClassName = "Microsoft.AppCenter.Unity.WrapperSdk";
+        public static string WrapperSdkVersionFieldName = "WrapperSdkVersion";
     }
 }

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/AppCenterEditorSDK/Constants.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/AppCenterEditorSDK/Constants.cs
@@ -4,6 +4,6 @@
     {
         public const string UnknownVersion = "Unknown";
         public const string WrapperSdkClassName = "Microsoft.AppCenter.Unity.WrapperSdk";
-        public static string WrapperSdkVersionFieldName = "WrapperSdkVersion";
+        public const string WrapperSdkVersionFieldName = "WrapperSdkVersion";
     }
 }

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
@@ -477,11 +477,11 @@ namespace AppCenterEditor
             if (!string.IsNullOrEmpty(InstalledSdkVersion))
                 return;
 
+            var packageTypes = new Dictionary<AppCenterSDKPackage, Type>();
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 try
                 {
-                    var packageTypes = new Dictionary<AppCenterSDKPackage, Type>();
                     foreach (var type in assembly.GetTypes())
                     {
                         if (type.FullName == Constants.WrapperSdkClassName)
@@ -507,10 +507,6 @@ namespace AppCenterEditor
                             }
                         }
                     }
-                    foreach (var packageType in packageTypes)
-                    {
-                        packageType.Key.GetInstalledVersion(packageType.Value, InstalledSdkVersion);
-                    }
                 }
                 catch (ReflectionTypeLoadException)
                 {
@@ -521,6 +517,10 @@ namespace AppCenterEditor
                     }
                     continue;
                 }
+            }
+            foreach (var packageType in packageTypes)
+            {
+                packageType.Key.GetInstalledVersion(packageType.Value, InstalledSdkVersion);
             }
         }
 

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
@@ -283,7 +283,7 @@ namespace AppCenterEditor
         {
             GUILayout.Space(5);
             EditorGUILayout.LabelField(string.Format("SDK {0} is installed", string.IsNullOrEmpty(InstalledSdkVersion) ? Constants.UnknownVersion : InstalledSdkVersion),
-                       TitleStyle, GUILayout.MinWidth(EditorGUIUtility.currentViewWidth));
+                TitleStyle, GUILayout.MinWidth(EditorGUIUtility.currentViewWidth));
             GUILayout.Space(5);
         }
 
@@ -405,7 +405,7 @@ namespace AppCenterEditor
             {
                 IEnumerable<AppCenterSDKPackage> installedPackages = AppCenterSDKPackage.GetInstalledPackages();
                 RemoveSdkBeforeUpdate();
-                PackagesInstaller.ImportLatestSDK(installedPackages, LatestSdkVersion);
+                PackagesInstaller.ImportLatestSDK(installedPackages, LatestSdkVersion, AppCenterEditorPrefsSO.Instance.SdkPath);
             }
         }
 

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
@@ -12,7 +12,7 @@ namespace AppCenterEditor
     {
         private enum SDKState
         {
-            SDKNotInstalled, 
+            SDKNotInstalled,
             SDKNotInstalledAndInstalling,
             SDKNotFull,
             SDKNotFullAndInstalling,
@@ -125,40 +125,34 @@ namespace AppCenterEditor
                 switch (SDKstate)
                 {
                     case SDKState.SDKNotInstalled:
-                        {
-                            ShowNOSDKLabel();
-                            ShowInstallButton();
-                            break;
-                        }
+                        ShowNOSDKLabel();
+                        ShowInstallButton();
+                        break;
+
                     case SDKState.SDKNotInstalledAndInstalling:
-                        {
-                            ShowNOSDKLabel();
-                            ShowInstallingButton();
-                            break;
-                        }
+                        ShowNOSDKLabel();
+                        ShowInstallingButton();
+                        break;
+
                     case SDKState.SDKNotFull:
-                        {
-                            ShowSdkInstalledLabel();
-                            ShowFolderObject();
-                            ShowInstallButton();
-                            ShowRemoveButton();
-                            break;
-                        }
+                        ShowSdkInstalledLabel();
+                        ShowFolderObject();
+                        ShowInstallButton();
+                        ShowRemoveButton();
+                        break;
+
                     case SDKState.SDKNotFullAndInstalling:
-                        {
-                            ShowSdkInstalledLabel();
-                            ShowFolderObject();
-                            ShowInstallingButton();
-                            ShowRemoveButton();
-                            break;
-                        }
+                        ShowSdkInstalledLabel();
+                        ShowFolderObject();
+                        ShowInstallingButton();
+                        ShowRemoveButton();
+                        break;
+
                     case SDKState.SDKIsFull:
-                        {
-                            ShowSdkInstalledLabel();
-                            ShowFolderObject();
-                            ShowRemoveButton();
-                            break;
-                        }
+                        ShowSdkInstalledLabel();
+                        ShowFolderObject();
+                        ShowRemoveButton();
+                        break;
                 }
             }
             if (SDKstate == SDKState.SDKIsFull || SDKstate == SDKState.SDKNotFull)
@@ -276,8 +270,7 @@ namespace AppCenterEditor
             }
             else
             {
-                EditorGUILayout.LabelField(
-                    "An SDK was detected, but we were unable to find the directory. Drag-and-drop the top-level App Center SDK folder below.",
+                EditorGUILayout.LabelField("An SDK was detected, but we were unable to find the directory. Drag-and-drop the top-level App Center SDK folder below.",
                     AppCenterEditorHelper.uiStyle.GetStyle("orTxt"));
             }
 
@@ -299,7 +292,7 @@ namespace AppCenterEditor
         private static void ShowSdkInstalledLabel()
         {
             EditorGUILayout.LabelField(string.Format("SDK {0} is installed", string.IsNullOrEmpty(InstalledSdkVersion) ? Constants.UnknownVersion : InstalledSdkVersion),
-                       TitleStyle, GUILayout.MinWidth(EditorGUIUtility.currentViewWidth));
+                TitleStyle, GUILayout.MinWidth(EditorGUIUtility.currentViewWidth));
         }
 
         private static void ShowInstallingButton()
@@ -328,7 +321,7 @@ namespace AppCenterEditor
                 if (GUILayout.Button("Install all App Center SDK packages", AppCenterEditorHelper.uiStyle.GetStyle("Button"), GUILayout.MaxWidth(buttonWidth), GUILayout.MinHeight(32)))
                 {
                     IsInstalling = true;
-                    ImportLatestSDK();
+                    PackagesInstaller.ImportLatestSDK(GetNotInstalledPackages(), LatestSdkVersion);
                 }
                 GUILayout.FlexibleSpace();
             }
@@ -338,11 +331,6 @@ namespace AppCenterEditor
         {
             EditorGUILayout.LabelField("No SDK is installed.", TitleStyle, GUILayout.MinWidth(EditorGUIUtility.currentViewWidth));
             GUILayout.Space(10);
-        }
-
-        public static void ImportLatestSDK(string existingSdkPath = null)
-        {
-            PackagesInstaller.ImportLatestSDK(GetNotInstalledPackages(), LatestSdkVersion, existingSdkPath);
         }
 
         public static bool AreSomePackagesInstalled()
@@ -427,7 +415,6 @@ namespace AppCenterEditor
                 IEnumerable<AppCenterSDKPackage> installedPackages = AppCenterSDKPackage.GetInstalledPackages();
                 RemoveSdkBeforeUpdate();
                 PackagesInstaller.ImportLatestSDK(installedPackages, LatestSdkVersion);
-               // ImportLatestSDK(AppCenterEditorPrefsSO.Instance.SdkPath);
             }
         }
 
@@ -503,27 +490,35 @@ namespace AppCenterEditor
             {
                 try
                 {
+                    var packageTypes = new Dictionary<AppCenterSDKPackage, Type>();
                     foreach (var type in assembly.GetTypes())
                     {
-                        if (type.FullName == "Microsoft.AppCenter.Unity.WrapperSdk")
+                        if (type.FullName == Constants.WrapperSdkClassName)
                         {
                             foreach (var field in type.GetFields())
                             {
-                                if (field.Name == "WrapperSdkVersion")
+                                if (field.Name == Constants.WrapperSdkVersionFieldName)
                                 {
                                     InstalledSdkVersion = field.GetValue(field).ToString();
                                     break;
                                 }
                             }
                         }
-                    }
-
-                    foreach (var type in assembly.GetTypes())
-                    {
-                        foreach (var package in AppCenterSDKPackage.SupportedPackages)
+                        else
                         {
-                            package.CheckIfInstalled(type);
+                            foreach (var package in AppCenterSDKPackage.SupportedPackages)
+                            {
+                                if (type.FullName == package.TypeName)
+                                {
+                                    package.IsInstalled = true;
+                                    packageTypes[package] = type;
+                                }
+                            }
                         }
+                    }
+                    foreach (var packageType in packageTypes)
+                    {
+                        packageType.Key.GetInstalledVersion(packageType.Value, InstalledSdkVersion);
                     }
                 }
                 catch (ReflectionTypeLoadException)

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/SDKPackage/AppCenterSDKPackage.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/SDKPackage/AppCenterSDKPackage.cs
@@ -18,7 +18,7 @@ namespace AppCenterEditor
         };
 
         public string InstalledVersion { get; private set; }
-        public bool IsInstalled { get; private set; }
+        public bool IsInstalled { get; set; }
         public bool IsPackageInstalling { get; set; }
         public bool IsObjectFieldActive { get; set; }
         protected abstract bool IsSupportedForWSA { get; }
@@ -121,7 +121,7 @@ namespace AppCenterEditor
                 {
                     GUILayout.FlexibleSpace();
                     var labelStyle = new GUIStyle(AppCenterEditorHelper.uiStyle.GetStyle("versionText"));
-                    EditorGUILayout.LabelField(string.Format("App Center {0} SDK {1} is installed", Name, sdkPackageVersion), labelStyle);                    
+                    EditorGUILayout.LabelField(string.Format("App Center {0} SDK {1} is installed", Name, sdkPackageVersion), labelStyle);
                     GUILayout.FlexibleSpace();
                 }
 
@@ -199,23 +199,19 @@ namespace AppCenterEditor
             }
         }
 
-        public void CheckIfInstalled(Type type)
+        public void GetInstalledVersion(Type type, string coreVersion)
         {
-            if (type.FullName == TypeName)
+            foreach (var field in type.GetFields())
             {
-                IsInstalled = true;
-                foreach (var field in type.GetFields())
+                if (field.Name == VersionFieldName)
                 {
-                    if (field.Name == VersionFieldName)
-                    {
-                        InstalledVersion = field.GetValue(field).ToString();
-                        break;
-                    }
+                    InstalledVersion = field.GetValue(field).ToString();
+                    break;
                 }
-                if (string.IsNullOrEmpty(InstalledVersion))
-                {
-                    InstalledVersion = string.IsNullOrEmpty(AppCenterEditorSDKTools.InstalledSdkVersion) ? Constants.UnknownVersion : AppCenterEditorSDKTools.InstalledSdkVersion;
-                }
+            }
+            if (string.IsNullOrEmpty(InstalledVersion))
+            {
+                InstalledVersion = string.IsNullOrEmpty(coreVersion) ? Constants.UnknownVersion : coreVersion;
             }
         }
 

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Utils/EdExLoggerFactory.cs.meta
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Utils/EdExLoggerFactory.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9e8a225cae6ca3b4492eb8c47db9f102
+guid: ecaed167bfab43f4b952d32525e60583
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
Do not enumerate assembly classes twice when looking for installed packages