### PR TITLE
Do not log "Deleting package" when user pressed the 'Cancel' button in confirmation dialog

### DIFF
--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/SDKPackage/AppCenterSDKPackage.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/SDKPackage/AppCenterSDKPackage.cs
@@ -44,14 +44,13 @@ namespace AppCenterEditor
 
         private void RemovePackage(bool prompt = true)
         {
-            EdExLogger.LoggerInstance.LogWithTimeStamp(string.Format("Deleting {0} package...", Name));
             if (prompt && !EditorUtility.DisplayDialog("Confirm SDK Removal", string.Format("This action will remove the current {0} SDK.", Name), "Confirm", "Cancel"))
             {
                 return;
             }
+            EdExLogger.LoggerInstance.LogWithTimeStamp(string.Format("Deleting {0} package...", Name));
 
             var toDelete = new List<string>();
-
             string pluginsPath = Path.Combine(AppCenterEditorPrefsSO.Instance.SdkPath, "Plugins");
             string androidPath = Path.Combine(pluginsPath, "Android");
             string sdkPath = Path.Combine(pluginsPath, "AppCenterSDK");

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/SDKPackage/AppCenterSDKPackage.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/SDKPackage/AppCenterSDKPackage.cs
@@ -48,7 +48,7 @@ namespace AppCenterEditor
             {
                 return;
             }
-            EdExLogger.LoggerInstance.LogWithTimeStamp(string.Format("Deleting {0} package...", Name));
+            EdExLogger.LoggerInstance.LogWithTimeStamp(string.Format("Removing {0} package...", Name));
 
             var toDelete = new List<string>();
             string pluginsPath = Path.Combine(AppCenterEditorPrefsSO.Instance.SdkPath, "Plugins");
@@ -94,7 +94,7 @@ namespace AppCenterEditor
 
             if (deleted)
             {
-                EdExLogger.LoggerInstance.LogWithTimeStamp(string.Format("{0} package deleted.", Name));
+                EdExLogger.LoggerInstance.LogWithTimeStamp(string.Format("{0} package removed.", Name));
                 AppCenterEditor.RaiseStateUpdate(AppCenterEditor.EdExStates.OnSuccess, string.Format("App Center {0} SDK removed.", Name));
 
                 // HACK for 5.4, AssetDatabase.Refresh(); seems to cause the install to fail.


### PR DESCRIPTION
Do not log "Deleting package" when user pressed the 'Cancel' button in confirmation dialog