### PR TITLE
Do not remove file AppCenterSettingsAdvanced.asset when SDK is updating from Extension.

### DIFF
--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
@@ -414,7 +414,9 @@ namespace AppCenterEditor
             var skippedFiles = new[]
             {
                 "AppCenterSettings.asset",
-                "AppCenterSettings.asset.meta"
+                "AppCenterSettings.asset.meta",
+                "AppCenterSettingsAdvanced.asset",
+                "AppCenterSettingsAdvanced.asset.meta"
             };
 
             RemoveAndroidSettings();


### PR DESCRIPTION
It requires to not remove file `AppCenterSettingsAdvanced.asset` when SDK is updating from Extension.
Files `AppCenterSettingsAdvanced.asset` and `AppCenterSettingsAdvanced.asset.meta` were added to list of exluded files what should not be delete.