### PR TITLE
Fix outdated SDKs behavior

### DIFF
--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorMenu.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorMenu.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEditor;
 
 namespace AppCenterEditor
@@ -16,7 +16,7 @@ namespace AppCenterEditor
 
         public static void DrawMenu()
         {
-            if (AppCenterEditorSDKTools.IsInstalled && AppCenterEditorSDKTools.isSdkSupported)
+            if (AppCenterEditorSDKTools.IsInstalled)
                 _menuState = (MenuStates)AppCenterEditorPrefsSO.Instance.curMainMenuIdx;
 
             var sdksButtonStyle = AppCenterEditorHelper.uiStyle.GetStyle("textButton");

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/SDKPackage/AppCenterSDKPackage.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/SDKPackage/AppCenterSDKPackage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -211,7 +211,7 @@ namespace AppCenterEditor
             }
             if (string.IsNullOrEmpty(InstalledVersion))
             {
-                InstalledVersion = string.IsNullOrEmpty(coreVersion) ? Constants.UnknownVersion : coreVersion;
+                InstalledVersion = Constants.UnknownVersion;
             }
         }
 


### PR DESCRIPTION
Now, if package version is not found, we don't take core one.
We also suggest an update if at least one of the versions is inconsistent or outdated.