### PR TITLE
Improve exception handling and fix Unity Editor console warning

### DIFF
--- a/Source/Assets/AppCenterEditorExtensions/Editor/AppCenterEditor.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/AppCenterEditor.cs
@@ -26,12 +26,7 @@ namespace AppCenterEditor
         {
             get
             {
-                if (scrollInnerContainer != null)
-                {
-                    return scrollInnerContainer.width;
-                }
-
-                return EditorGUIUtility.currentViewWidth;
+                return scrollInnerContainer.width;
             }
         }
 

--- a/Source/Assets/AppCenterEditorExtensions/Editor/AppCenterEditor.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/AppCenterEditor.cs
@@ -130,12 +130,10 @@ namespace AppCenterEditor
             scrollPosition = GUILayout.BeginScrollView(scrollPosition, false, false, GUILayout.Width(window.position.width), GUILayout.Height(window.position.height));
             // Gets a rectangle with size of inner scroll area.
             scrollInnerContainer = EditorGUILayout.BeginHorizontal(GUILayout.ExpandHeight(true), GUILayout.ExpandWidth(true));
-            using (
-                new AppCenterGuiFieldHelper.UnityVertical(
-                    GUILayout.Width(scrollInnerContainer.width),
-                    GUILayout.MaxWidth(scrollInnerContainer.width),
-                    GUILayout.Height(scrollInnerContainer.height)
-                    ))
+            using (new AppCenterGuiFieldHelper.UnityVertical(
+                GUILayout.Width(scrollInnerContainer.width),
+                GUILayout.MaxWidth(scrollInnerContainer.width),
+                GUILayout.Height(scrollInnerContainer.height)))
             {
                 GUI.enabled = IsGUIEnabled();
                 AppCenterEditorHeader.DrawHeader();

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/AppCenterEditorSDK/PackagesInstaller.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/AppCenterEditorSDK/PackagesInstaller.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEditor;
 
 namespace AppCenterEditor
@@ -28,6 +29,10 @@ namespace AppCenterEditor
                         AppCenterEditorPrefsSO.Instance.SdkPath = string.IsNullOrEmpty(existingSdkPath) ? AppCenterEditorHelper.DEFAULT_SDK_LOCATION : existingSdkPath;
                         //AppCenterEditorDataService.SaveEnvDetails();
                         EdExLogger.LoggerInstance.LogWithTimeStamp("App Center SDK install complete");
+                    }
+                    catch (Exception exception)
+                    {
+                        EdExLogger.LoggerInstance.LogError("Failed to import packages: " + exception);
                     }
                     finally
                     {

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
@@ -305,7 +305,15 @@ namespace AppCenterEditor
                 if (GUILayout.Button("Install all App Center SDK packages", AppCenterEditorHelper.uiStyle.GetStyle("Button"), GUILayout.MaxWidth(buttonWidth), GUILayout.MinHeight(32)))
                 {
                     IsInstalling = true;
-                    PackagesInstaller.ImportLatestSDK(GetNotInstalledPackages(), LatestSdkVersion);
+                    try
+                    {
+                        PackagesInstaller.ImportLatestSDK(GetNotInstalledPackages(), LatestSdkVersion);
+                    }
+                    catch (Exception exception)
+                    {
+                        EdExLogger.LoggerInstance.LogError("Failed to install SDK packages: " + exception);
+                        IsInstalling = false;
+                    }
                 }
                 GUILayout.FlexibleSpace();
             }
@@ -427,6 +435,7 @@ namespace AppCenterEditor
                 catch (Exception exception)
                 {
                     EdExLogger.LoggerInstance.LogError("Failed to upgrade SDK: " + exception);
+                    IsUpgrading = false;
                 }
             }
         }

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/AppCenterEditorSDKTools.cs
@@ -411,16 +411,23 @@ namespace AppCenterEditor
                 }
             }
 
-            return isOutdated;            
+            return isOutdated;
         }
 
         private static void UpgradeSdk()
         {
             if (EditorUtility.DisplayDialog("Confirm SDK Upgrade", "This action will remove the current App Center SDK and install the lastet version.", "Confirm", "Cancel"))
             {
-                IEnumerable<AppCenterSDKPackage> installedPackages = AppCenterSDKPackage.GetInstalledPackages();
-                RemoveSdkBeforeUpdate();
-                PackagesInstaller.ImportLatestSDK(installedPackages, LatestSdkVersion, AppCenterEditorPrefsSO.Instance.SdkPath);
+                try
+                {
+                    var installedPackages = AppCenterSDKPackage.GetInstalledPackages();
+                    RemoveSdkBeforeUpdate();
+                    PackagesInstaller.ImportLatestSDK(installedPackages, LatestSdkVersion, AppCenterEditorPrefsSO.Instance.SdkPath);
+                }
+                catch (Exception exception)
+                {
+                    EdExLogger.LoggerInstance.LogError("Failed to upgrade SDK: " + exception);
+                }
             }
         }
 

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/SDKPackage/AppCenterSDKPackage.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Panels/SDKPackage/AppCenterSDKPackage.cs
@@ -177,8 +177,7 @@ namespace AppCenterEditor
                     {
                         if (GUILayout.Button("Install SDK", AppCenterEditorHelper.uiStyle.GetStyle("textButton")))
                         {
-                            AppCenterEditorSDKTools.IsInstalling = true;
-                            IsPackageInstalling = true;
+                            AppCenterEditorSDKTools.IsInstalling = IsPackageInstalling = true;
                             ImportLatestPackageSDK();
                         }
                     }
@@ -217,7 +216,15 @@ namespace AppCenterEditor
 
         private void ImportLatestPackageSDK()
         {
-            PackagesInstaller.ImportLatestSDK(new[] { this }, AppCenterEditorSDKTools.LatestSdkVersion);
+            try
+            {
+                PackagesInstaller.ImportLatestSDK(new[] { this }, AppCenterEditorSDKTools.LatestSdkVersion);
+            }
+            catch (Exception exception)
+            {
+                EdExLogger.LoggerInstance.LogError("Failed to import package: " + exception);
+                AppCenterEditorSDKTools.IsInstalling = IsPackageInstalling = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Add more exceptions handling and fix the following warning:
The result of comparing value type 'UnityEngine.Rect' with null is always 'true'