### PR TITLE
Find a new EDEX_ROOT if the current directory doesn't exist

### DIFF
--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Utils/AppCenterEditorHelper.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Utils/AppCenterEditorHelper.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEditor;
 using UnityEngine;
+using System;
 using System.IO;
 
 namespace AppCenterEditor
@@ -7,14 +8,15 @@ namespace AppCenterEditor
     [InitializeOnLoad]
     public static partial class AppCenterEditorHelper
     {
-        public static string EDEX_NAME = "AppCenter_EditorExtensions";
-        public static string EDEX_ROOT = Application.dataPath + "/AppCenterEditorExtensions/Editor";
+        public static string EDEX_NAME = "AppCenterEditorExtensions";
+        public static string EDEX_ROOT = Path.Combine(Application.dataPath, "AppCenterEditorExtensions/Editor");
         public static string APPCENTER_SETTINGS_TYPENAME = "AppCenterSettings";
         public static string APPCENTER_WRAPPER_SDK_TYPENAME = "WrapperSdk";
         public static string DEFAULT_SDK_LOCATION = "Assets/AppCenter";
         public static string DEFAULT_SDK_LOCATION_PATH = Application.dataPath + "/AppCenter";
         public static string MSG_SPIN_BLOCK = "{\"useSpinner\":true, \"blockUi\":true }";
         public static string ANALYTICS_SDK_DOWNLOAD_PATH = "/Resources/AppCenterAnalyticsUnitySdk.unitypackage";
+        public static string AUTH_SDK_DOWNLOAD_PATH = "/Resources/AppCenterAuthUnitySdk.unitypackage";
         public static string CRASHES_SDK_DOWNLOAD_PATH = "/Resources/AppCenterCrashesUnitySdk.unitypackage";
         public static string DISTRIBUTE_SDK_DOWNLOAD_PATH = "/Resources/AppCenterDistributeUnitySdk.unitypackage";
         public static string EDEX_UPGRADE_PATH = "/Resources/AppCenterUnityEditorExtensions.unitypackage";
@@ -41,13 +43,42 @@ namespace AppCenterEditor
         private static GUISkin GetUiStyle()
         {
             var searchRoot = string.IsNullOrEmpty(EDEX_ROOT) ? Application.dataPath : EDEX_ROOT;
-            var guiPaths = Directory.GetFiles(searchRoot, "AppCenterStyles.guiskin", SearchOption.AllDirectories);
+            string[] guiPaths;
+
+            if (Directory.Exists(searchRoot))
+            {
+                guiPaths = FindGuiSkinPaths(searchRoot);
+            }
+            else
+            {
+                EDEX_ROOT = FindEdexRoot();
+                guiPaths = FindGuiSkinPaths(EDEX_ROOT);
+            }            
+                
             foreach (var eachPath in guiPaths)
             {
-                var loadPath = eachPath.Substring(eachPath.LastIndexOf("Assets/"));
-                return (GUISkin)AssetDatabase.LoadAssetAtPath(loadPath, typeof(GUISkin));
+                var loadPath = eachPath.Substring(eachPath.LastIndexOf("Assets" + Path.DirectorySeparatorChar, StringComparison.Ordinal));
+                return (GUISkin) AssetDatabase.LoadAssetAtPath(loadPath, typeof(GUISkin));
             }
+
             return null;
+        }
+
+        private static string[] FindGuiSkinPaths(string searchPath)
+        {
+            return Directory.GetFiles(searchPath, "AppCenterStyles.guiskin", SearchOption.AllDirectories);
+        }
+        
+        private static string FindEdexRoot()
+        {
+            var fileList = Directory.GetDirectories(Application.dataPath, "*" + EDEX_NAME, SearchOption.AllDirectories);
+            if (fileList.Length == 0)
+            {
+                throw new FileNotFoundException(EDEX_NAME + " not found");
+            }
+
+            var relativePath = fileList[0].Substring(fileList[0].LastIndexOf("Assets" + Path.DirectorySeparatorChar, StringComparison.Ordinal));
+            return Path.Combine(relativePath, "Editor");
         }
     }
 }

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Utils/AppCenterEditorHelper.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Utils/AppCenterEditorHelper.cs
@@ -16,7 +16,6 @@ namespace AppCenterEditor
         public static string DEFAULT_SDK_LOCATION_PATH = Application.dataPath + "/AppCenter";
         public static string MSG_SPIN_BLOCK = "{\"useSpinner\":true, \"blockUi\":true }";
         public static string ANALYTICS_SDK_DOWNLOAD_PATH = "/Resources/AppCenterAnalyticsUnitySdk.unitypackage";
-        public static string AUTH_SDK_DOWNLOAD_PATH = "/Resources/AppCenterAuthUnitySdk.unitypackage";
         public static string CRASHES_SDK_DOWNLOAD_PATH = "/Resources/AppCenterCrashesUnitySdk.unitypackage";
         public static string DISTRIBUTE_SDK_DOWNLOAD_PATH = "/Resources/AppCenterDistributeUnitySdk.unitypackage";
         public static string EDEX_UPGRADE_PATH = "/Resources/AppCenterUnityEditorExtensions.unitypackage";
@@ -71,13 +70,13 @@ namespace AppCenterEditor
         
         private static string FindEdexRoot()
         {
-            var fileList = Directory.GetDirectories(Application.dataPath, "*" + EDEX_NAME, SearchOption.AllDirectories);
-            if (fileList.Length == 0)
+            var directoryList = Directory.GetDirectories(Application.dataPath, "*" + EDEX_NAME, SearchOption.AllDirectories);
+            if (directoryList.Length == 0)
             {
-                throw new FileNotFoundException(EDEX_NAME + " not found");
+                throw new DirectoryNotFoundException(EDEX_NAME + " not found");
             }
 
-            var relativePath = fileList[0].Substring(fileList[0].LastIndexOf("Assets" + Path.DirectorySeparatorChar, StringComparison.Ordinal));
+            var relativePath = directoryList[0].Substring(directoryList[0].LastIndexOf("Assets" + Path.DirectorySeparatorChar, StringComparison.Ordinal));
             return Path.Combine(relativePath, "Editor");
         }
     }


### PR DESCRIPTION
I am still getting a bunch of errors and AppCenter editor window doesn't work if AppCenterEditorExtensions folder is moved out of the project root. 
![photo_2020-03-05_01-00-26](https://user-images.githubusercontent.com/6983110/75927155-e0e0b580-5e7c-11ea-96e1-e0a7d51f07fe.jpg)

The issue can be resolved just by checking if edex folder exists by the given path and updating the path if the check is failed in the GetUiStyle() method. 
I have tested the solution in Unity 2018.4.12f and 2019.3.3f on OS X and Windows 10.
