### PR TITLE
Version check value parsing fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 2.0.1 (in development)
 
+* **[Fix]** Fix version check date time value parsing. 
 * **[Improvement]** Detect `AppCenterEditorExtensions` location automatically.
 
 ## Release 2.0.0

--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Utils/AppCenterEditorPrefsSO.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/Utils/AppCenterEditorPrefsSO.cs
@@ -56,7 +56,7 @@ namespace AppCenterEditor
         {
             get
             {
-                return PlayerPrefs.HasKey(SdkLastCheckDateKey) ? DateTime.Parse(PlayerPrefs.GetString(SdkLastCheckDateKey)) : _lastSdkVersionCheck;
+                return PlayerPrefs.HasKey(SdkLastCheckDateKey) ? DateTime.Parse(PlayerPrefs.GetString(SdkLastCheckDateKey), CultureInfo.InvariantCulture) : _lastSdkVersionCheck;
             }
         }
 
@@ -64,7 +64,7 @@ namespace AppCenterEditor
         {
             get
             {
-                return PlayerPrefs.HasKey(EdExLastCheckDateKey) ? DateTime.Parse(PlayerPrefs.GetString(EdExLastCheckDateKey)) : _lastEdExVersionCheck;
+                return PlayerPrefs.HasKey(EdExLastCheckDateKey) ? DateTime.Parse(PlayerPrefs.GetString(EdExLastCheckDateKey), CultureInfo.InvariantCulture) : _lastEdExVersionCheck;
             }
         }
 


### PR DESCRIPTION
Exception was thrown during 'EdExLastCheckDateKey' preference parsing in 'EdSet_lastEdExVersionCheck' property getter. To fix this issue 'CultureInfo.InvariantCulture' was added to parse method.

[AB#79572](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/79572)