### PR TITLE
Fix cake version

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.34.1" />
+    <package id="Cake" version="0.37.0" />
 </packages>


### PR DESCRIPTION
Fix cake version. 
See https://github.com/cake-build/cake/issues/2695
```
Error: System.IO.FileLoadException: The assembly name is invalid.
```