### PR TITLE
Use UnityWebRequest.result instead of isNetworkError for unity 2020

### DIFF
--- a/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/AppCenterEditorSDK/AppCenterEditorHttp.cs
+++ b/Source/Assets/AppCenterEditorExtensions/Editor/Scripts/AppCenterEditorSDK/AppCenterEditorHttp.cs
@@ -75,7 +75,12 @@ namespace AppCenterEditor
             {
                 yield return downloadRequest.WWW.SendWebRequest();
 
+#if UNITY_2020_2_OR_NEWER
+                if (downloadRequest.WWW.result != UnityWebRequest.Result.ProtocolError
+                    && downloadRequest.WWW.result != UnityWebRequest.Result.ConnectionError)
+#else
                 if (!downloadRequest.WWW.isHttpError && !downloadRequest.WWW.isNetworkError)
+#endif
                 {
                     var downloadedFile = WriteResultFile(downloadRequest.Url, downloadRequest.WWW.downloadHandler.data);
                     downloadedFiles.Add(downloadedFile);


### PR DESCRIPTION
UnityWebRequest.isNetworkError is obsolete in unity 2020, so replacing it with the new API on version 2020 and higher.


**Related issues**:

[AB#88670](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/88670)
#55